### PR TITLE
Update common.js

### DIFF
--- a/lib/util/common.js
+++ b/lib/util/common.js
@@ -75,7 +75,7 @@ function formatParamUrl (url) {
     found = regex.exec(url)
   }
 
-  return url.replace(/::(\w+)$/, ':$1')
+  return url.replace(/::/g, ':')
 }
 
 function resolveLocalRef (jsonSchema, externalSchemas) {


### PR DESCRIPTION
simplify regex for path variables, does not need to limit to the end of the path